### PR TITLE
remove tier_duration and archived fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,12 @@ with a STAC Item.  This extension does not cover NFS solutions provided by PaaS 
 
 | Field Name  | Type   | Description |
 | ----------- | ------ | ----------- |
-| storage:min_tier_duration   | integer  | number of days for the shortest time tier restriction on access of an asset. |
-| storage:max_tier_duration   | integer  | number of days for the longest time tier restrictions on access of an asset. |
-| storage:archived            | bool    | descriptor for whether the data is "properly" archived according to implementers discretion |
 | storage:platform              | string    | The [cloud provider](#providers) where data is stored |
 | storage:region                | string    | The region where the data is stored. Relevant to speed of access and inter region egress costs (as defined by PaaS provider) |
 | storage:bucket                | string    | The bucket for the asset(s), used along with object path |
 | storage:object_path           | string    | The object_path for the asset, used along with bucket |
 | storage:requester_pays        | bool      | Is the data requester pays or is it data manager/cloud provider pays. *Defaults to false* |
 | storage:tier                  | string    | The title for the tier type (as defined by PaaS provider) |
-| storage:tier_duration         | integer   | Minimum storage duration (in days) required before additional fees |
 | storage:first_byte_latency    | string    | approximate time unit (milliseconds, minutes or hours) for accessing first byte of data |
 
 While these are all valid properties on an Item, they will typically be defined per-asset. If a field applies equally
@@ -76,8 +72,6 @@ Oracle:
 Alibaba: 
 - <https://www.alibabacloud.com/product/oss/pricing>
 - <https://www.alibabacloud.com/help/doc-detail/51374.htm>
-
-All timestamps MUST be formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6).
 
 ## Contributing
 

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -127,29 +127,9 @@
           "title": "Tier",
           "type": "string"
         },
-        "storage:tier_duration": {
-          "title": "Tier Duration",
-          "type": "integer",
-          "default": 0
-        },
         "storage:first_byte_latency": {
-          "title": "Tier",
+          "title": "First Byte Latency",
           "type": "string"
-        },
-        "storage:min_tier_duration": {
-          "title": "Minimum Duration for Tier",
-          "type": "integer",
-          "default": 0
-        },
-        "storage:max_tier_duration": {
-          "title": "Maxiumum Duration for Tier",
-          "type": "integer",
-          "default": 0
-        },
-        "storage:archived": {
-          "title": "Archived",
-          "type": "boolean",
-          "default": false
         }
       }
     }


### PR DESCRIPTION
Resolves #3, #4, and #7.

Removes fields `tier_duration`, `min_tier_duration`, `max_tier_duration`, and `archived`.

This fields all have to do with management of assets across different types of storage within a cloud provider, but I think that there is too much variability between cloud providers to make a truly useful generic extension for this. Perhaps cloud specific extensions would work for that level of detail.

Left in `tier` and `first_byte_latency`, as these fields indicate, for a given provider, how it is stored and some idea as to how quick it is to access.